### PR TITLE
Add Jest test harness

### DIFF
--- a/backend-pim/index.js
+++ b/backend-pim/index.js
@@ -9,6 +9,7 @@ console.log("DATABASE_URL:", process.env.DATABASE_URL);
 import express from 'express';
 import cors from 'cors';
 import jwt from 'jsonwebtoken'; // <- ✅ aquí
+import bcrypt from 'bcryptjs';
 import { PrismaClient } from './generated/prisma/index.js';
 
 // Crear carpeta 'uploads' si no existeix
@@ -997,7 +998,6 @@ app.get('/users/:id', authenticateToken, async (req, res) => {
 
 
 /** Endpoint per registre d'usuari */
-import bcrypt from 'bcryptjs';
 
 app.post('/users/register', async (req, res) => {
   const { name, email, password } = req.body;
@@ -1205,6 +1205,11 @@ app.get('/change-history', authenticateToken, async (req, res) => {
 /** 🚀 INICI DEL SERVIDOR */
 const PORT = process.env.PORT || 4000;
 app.use('/uploads', express.static(uploadDir));
-app.listen(PORT, () => {
-  console.log(`Servidor escoltant a http://localhost:${PORT}`);
-});
+if (process.env.NODE_ENV !== 'test') {
+  app.listen(PORT, () => {
+    console.log(`Servidor escoltant a http://localhost:${PORT}`);
+  });
+}
+
+export default app;
+export { prisma };

--- a/backend-pim/package.json
+++ b/backend-pim/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "dev": "node index.js"
   },
   "keywords": [],
@@ -25,6 +25,8 @@
   "devDependencies": {
     "autoprefixer": "^10.4.21",
     "postcss": "^8.5.6",
-    "tailwindcss": "^4.1.11"
+    "tailwindcss": "^4.1.11",
+    "jest": "^29.7.0",
+    "supertest": "^6.3.3"
   }
 }

--- a/backend-pim/tests/api.test.js
+++ b/backend-pim/tests/api.test.js
@@ -1,0 +1,23 @@
+import request from 'supertest';
+import app, { prisma } from '../index.js';
+import { jest } from '@jest/globals';
+
+beforeAll(() => {
+  process.env.DATABASE_URL = 'file:./prisma/dev.db';
+  process.env.JWT_SECRET = 'testsecret';
+});
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+test('GET /products returns data structure', async () => {
+  jest.spyOn(prisma.product, 'findMany').mockResolvedValueOnce([]);
+  jest.spyOn(prisma.product, 'count').mockResolvedValueOnce(0);
+
+  const res = await request(app).get('/products');
+  expect(res.status).toBe(200);
+  expect(res.body).toHaveProperty('data');
+  expect(Array.isArray(res.body.data)).toBe(true);
+  expect(res.body).toHaveProperty('pagination');
+});


### PR DESCRIPTION
## Summary
- export Express `app` and `prisma` from the backend so tests can import it
- add Jest/Supertest dev deps and test script
- implement a sample API test for `/products`

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a825abc64832f86473fc7a1d34f7c