### PR TITLE
Fix logging output for env info

### DIFF
--- a/backend-pim/index.js
+++ b/backend-pim/index.js
@@ -4,8 +4,10 @@ import path from 'path';
 import fs from 'fs';
 import dotenv from 'dotenv';
 dotenv.config();
-console.log("Ruta actual:", process.cwd());
-console.log("DATABASE_URL:", process.env.DATABASE_URL);
+if (process.env.NODE_ENV === 'development') {
+  console.log("Ruta actual:", process.cwd());
+  console.log("DATABASE_URL:", process.env.DATABASE_URL);
+}
 import express from 'express';
 import cors from 'cors';
 import jwt from 'jsonwebtoken'; // <- ✅ aquí


### PR DESCRIPTION
## Summary
- remove default logging of `cwd` and `DATABASE_URL`
- only emit these logs in development mode

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688a824db934832f8360b752332833e8