### PR TITLE
Add basic frontend auth flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
 # pim-mvp
+
+This repository contains a very small PIM (Product Information Management) MVP.
+
+## Frontend
+
+The frontend is built with React and Vite. To run it locally you need a `.env` file inside `frontend-pim` with the API URL:
+
+```
+VITE_API_URL=http://localhost:4000
+```
+
+After installing dependencies run `npm run dev` inside `frontend-pim`.
+
+## Backend
+
+The backend is an Express API located in `backend-pim`.
+
+Run the tests with:
+
+```
+npm --prefix backend-pim test
+```

--- a/frontend-pim/.env
+++ b/frontend-pim/.env
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:4000

--- a/frontend-pim/src/App.jsx
+++ b/frontend-pim/src/App.jsx
@@ -6,6 +6,7 @@ import ProductsPage from "./pages/ProductsPage";
 import CategoriesPage from "./pages/CategoriesPage";
 import LogsPage from "./pages/LogsPage";
 import Login from "./pages/Login";
+import PrivateRoute from "./components/PrivateRoute";
 import "./index.css";
 
 function App() {
@@ -13,12 +14,14 @@ function App() {
     <Router>
       <Routes>
         <Route path="/login" element={<Login />} />
-        <Route path="/" element={<MainLayout />}>
-          <Route index element={<Dashboard />} />
-          <Route path="variants" element={<VariantsPage />} />
-          <Route path="products" element={<ProductsPage />} />
-          <Route path="categories" element={<CategoriesPage />} />
-          <Route path="logs" element={<LogsPage />} />
+        <Route element={<PrivateRoute />}>
+          <Route path="/" element={<MainLayout />}>
+            <Route index element={<Dashboard />} />
+            <Route path="variants" element={<VariantsPage />} />
+            <Route path="products" element={<ProductsPage />} />
+            <Route path="categories" element={<CategoriesPage />} />
+            <Route path="logs" element={<LogsPage />} />
+          </Route>
         </Route>
         <Route path="*" element={<Navigate to="/" />} />
       </Routes>

--- a/frontend-pim/src/components/Header.jsx
+++ b/frontend-pim/src/components/Header.jsx
@@ -1,12 +1,22 @@
-import { Link } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 export default function Header() {
+  const navigate = useNavigate();
+
+  const handleLogout = () => {
+    localStorage.removeItem("token");
+    navigate("/login");
+  };
+
   return (
     <header className="w-full bg-white border-b border-brand-lighter px-6 py-4 flex items-center justify-between shadow-sm">
       <h1 className="text-xl font-semibold text-brand">Gestió de productes</h1>
-      <Link to="/login" className="bg-accent hover:bg-orange-600 text-white px-4 py-2 rounded-md font-medium">
+      <button
+        onClick={handleLogout}
+        className="bg-accent hover:bg-brand text-white px-4 py-2 rounded-md font-medium"
+      >
         Tancar sessió
-      </Link>
+      </button>
     </header>
   );
 }

--- a/frontend-pim/src/components/PrivateRoute.jsx
+++ b/frontend-pim/src/components/PrivateRoute.jsx
@@ -1,0 +1,6 @@
+import { Navigate, Outlet } from "react-router-dom";
+
+export default function PrivateRoute() {
+  const token = localStorage.getItem("token");
+  return token ? <Outlet /> : <Navigate to="/login" replace />;
+}

--- a/frontend-pim/src/pages/Login.jsx
+++ b/frontend-pim/src/pages/Login.jsx
@@ -1,11 +1,53 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+
 export default function Login() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError("");
+    try {
+      const res = await fetch(`${import.meta.env.VITE_API_URL}/users/login`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, password }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error || "Error d' autenticació");
+        return;
+      }
+      localStorage.setItem("token", data.token);
+      navigate("/dashboard");
+    } catch (err) {
+      setError("Error de connexió");
+    }
+  };
+
   return (
     <div className="flex items-center justify-center h-screen bg-gray-100">
-      <form className="bg-white p-6 rounded shadow-md w-80">
+      <form onSubmit={handleSubmit} className="bg-white p-6 rounded shadow-md w-80">
         <h2 className="text-xl font-semibold mb-4">Inicia sessió</h2>
-        <input type="email" placeholder="Email" className="w-full mb-3 p-2 border rounded" />
-        <input type="password" placeholder="Contrasenya" className="w-full mb-4 p-2 border rounded" />
-        <button type="submit" className="w-full bg-blue-600 text-white py-2 rounded hover:bg-blue-700">
+        {error && <p className="text-red-600 mb-2 text-sm">{error}</p>}
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="w-full mb-3 p-2 border rounded"
+        />
+        <input
+          type="password"
+          placeholder="Contrasenya"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="w-full mb-4 p-2 border rounded"
+        />
+        <button type="submit" className="w-full bg-brand hover:bg-brand-light text-white py-2 rounded">
           Entrar
         </button>
       </form>

--- a/frontend-pim/tailwind.config.js
+++ b/frontend-pim/tailwind.config.js
@@ -4,11 +4,11 @@ export default {
   theme: {
     extend: {
       colors: {
-        brand: "#3f3f46",
-        "brand-light": "#52525b",
-        "brand-lighter": "#e4e4e7",
+        brand: "#C4000C",
+        "brand-light": "#E04A45",
+        "brand-lighter": "#FFD1D1",
         "brand-bg": "#f9f9f9",
-        accent: "#f97316",
+        accent: "#6B7280",
       },
       fontFamily: {
         sans: ["Inter", "sans-serif"],


### PR DESCRIPTION
## Summary
- implement login flow: fetch token and store in localStorage
- protect routes with new `PrivateRoute`
- allow logout from header
- update color palette for Tailwind
- document how to run frontend and backend

## Testing
- `npm --prefix backend-pim test` *(fails: Jest unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_688a86915ff4832f8f58ce0abd22bce0